### PR TITLE
Use local vendor copies for dependencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,10 +23,10 @@
     <script type="importmap">
     {
         "imports": {
-            "three": "https://cdn.jsdelivr.net/npm/three@0.158.0/build/three.module.js",
-            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.158.0/examples/jsm/",
-            "occt-import-js": "https://cdn.jsdelivr.net/npm/occt-import-js@0.0.26/dist/occt-import-js.module.js",
-            "rev-viewer": "https://cdn.jsdelivr.net/npm/rev-viewer@0.0.10/dist/rev-viewer.js"
+            "three": "./vendor/three/build/three.module.js",
+            "three/addons/": "./vendor/three/addons/",
+            "occt-import-js": "./vendor/occt-import-js/occt-import-js.module.js",
+            "rev-viewer": "./vendor/rev-viewer/rev-viewer.js"
         }
     }
     </script>

--- a/main.js
+++ b/main.js
@@ -14,8 +14,8 @@ const conversionLoaderElement = document.getElementById('conversion-loader');
 const convertBtn = document.getElementById('convert-btn');
 const downloadLink = document.getElementById('download-link');
 
-// Set occt-import-js worker path from CDN
-SetOCCTWorkerUrl('https://cdn.jsdelivr.net/npm/occt-import-js@0.0.26/dist/occt-import-js-worker.js');
+// Set occt-import-js worker path for local vendor copy
+SetOCCTWorkerUrl('./vendor/occt-import-js/occt-import-js-worker.js');
 
 function init() {
     // Scene

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,0 +1,12 @@
+This directory should contain local copies of required third-party libraries for offline use.
+
+Populate the following files using npm or CDN downloads:
+
+- three/build/three.module.js
+- three/addons/controls/OrbitControls.js
+- occt-import-js/occt-import-js.module.js
+- occt-import-js/occt-import-js-worker.js
+- occt-import-js/occt-import-js-worker.wasm
+- rev-viewer/rev-viewer.js
+
+These placeholder files should be replaced with the actual library files.

--- a/vendor/occt-import-js/occt-import-js-worker.js
+++ b/vendor/occt-import-js/occt-import-js-worker.js
@@ -1,0 +1,1 @@
+// Placeholder for occt-import-js-worker.js

--- a/vendor/occt-import-js/occt-import-js.module.js
+++ b/vendor/occt-import-js/occt-import-js.module.js
@@ -1,0 +1,1 @@
+// Placeholder for occt-import-js.module.js

--- a/vendor/rev-viewer/rev-viewer.js
+++ b/vendor/rev-viewer/rev-viewer.js
@@ -1,0 +1,1 @@
+// Placeholder for rev-viewer.js

--- a/vendor/three/addons/controls/OrbitControls.js
+++ b/vendor/three/addons/controls/OrbitControls.js
@@ -1,0 +1,1 @@
+// Placeholder for OrbitControls.js

--- a/vendor/three/build/three.module.js
+++ b/vendor/three/build/three.module.js
@@ -1,0 +1,1 @@
+// Placeholder for three.module.js


### PR DESCRIPTION
## Summary
- Switch import map to load local vendor copies of three.js, its addons, occt-import-js, and rev-viewer.
- Point occt-import-js to a local worker script and add placeholders for required vendor files.

## Testing
- ⚠️ `npm test` (no tests defined, command exits with error)


------
https://chatgpt.com/codex/tasks/task_e_68bfa39920d4832585c4ccdf3933ba84