### PR TITLE
Add basic rev-viewer implementation with tools helper

### DIFF
--- a/vendor/rev-viewer/rev-viewer.js
+++ b/vendor/rev-viewer/rev-viewer.js
@@ -1,1 +1,31 @@
-// Placeholder for rev-viewer.js
+import { importedImage } from './tools.js';
+
+export class Viewer {
+  constructor(container) {
+    this.container = container;
+    this.imageElement = null;
+  }
+
+  async load(file) {
+    const objectUrl = URL.createObjectURL(file);
+    try {
+      const img = await importedImage(objectUrl);
+      img.style.maxWidth = '100%';
+      img.style.maxHeight = '100%';
+      this.container.appendChild(img);
+      this.imageElement = img;
+    } catch (err) {
+      const msg = document.createElement('div');
+      msg.textContent = `Unable to display ${file.name}.`;
+      this.container.appendChild(msg);
+    }
+  }
+
+  dispose() {
+    if (this.imageElement) {
+      this.container.removeChild(this.imageElement);
+      URL.revokeObjectURL(this.imageElement.src);
+      this.imageElement = null;
+    }
+  }
+}

--- a/vendor/rev-viewer/tools.js
+++ b/vendor/rev-viewer/tools.js
@@ -1,0 +1,8 @@
+export function importedImage(url) {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Failed to load image'));
+    img.src = url;
+  });
+}


### PR DESCRIPTION
## Summary
- replace placeholder rev-viewer module with minimal implementation
- add tools helper exporting `importedImage` required by viewer

## Testing
- `node --check vendor/rev-viewer/rev-viewer.js`
- `node --check vendor/rev-viewer/tools.js`
- `node -e "import('./vendor/rev-viewer/rev-viewer.js').then(m => console.log('exports', Object.keys(m)))"`
- `node -e "import('./vendor/rev-viewer/tools.js').then(m => console.log('tools', Object.keys(m)))"`


------
https://chatgpt.com/codex/tasks/task_e_68bfab2ca4a08325a9d3936ece72764e