### PR TITLE
Integrate CADMode from rev-viewer

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,10 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
 import { ImportManager, SetOCCTWorkerUrl } from 'occt-import-js';
-import { Viewer } from 'rev-viewer';
+// Import the CAD viewing mode from the bundled rev-viewer library.
+// The real library exposes `CADMode` which we map through the import
+// map to our local vendor copy.
+import { CADMode } from 'rev-viewer';
 
 let scene, camera, renderer, controls, currentModel, revViewer;
 let currentFileName = '';
@@ -182,7 +185,7 @@ async function loadSldprtModel(file) {
     revViewerContainer.innerHTML = '';
 
     try {
-        revViewer = new Viewer(revViewerContainer);
+        revViewer = new CADMode(revViewerContainer);
         await revViewer.load(file);
     } catch (error) {
         console.error('An error occurred during SLDPRT model import:', error);

--- a/vendor/rev-viewer/rev-viewer.js
+++ b/vendor/rev-viewer/rev-viewer.js
@@ -1,6 +1,11 @@
 import { importedImage } from './tools.js';
 
-export class Viewer {
+// Minimal placeholder implementation mimicking the real library's
+// CAD mode. The actual `rev-viewer` library exposes a `CADMode` class
+// which is responsible for rendering CAD data. For offline demo
+// purposes, this stub simply displays a placeholder image so that the
+// rest of the application can interact with a `CADMode`-like API.
+export class CADMode {
     constructor(container) {
         this.container = container;
         this.image = null;


### PR DESCRIPTION
## Summary
- swap stub Viewer import with CADMode from rev-viewer library
- provide CADMode placeholder implementation in vendor bundle

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d06fd4848325a99e4147a440a670