### PR TITLE
Use absolute worker URL for occt-import-js

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,7 +18,9 @@ const convertBtn = document.getElementById('convert-btn');
 const downloadLink = document.getElementById('download-link');
 
 // Set occt-import-js worker path for local vendor copy
-SetOCCTWorkerUrl('./vendor/occt-import-js/dist/occt-import-js-worker.js');
+SetOCCTWorkerUrl(
+    new URL('./vendor/occt-import-js/dist/occt-import-js-worker.js', import.meta.url).href
+);
 
 // Log asset loading failures (e.g., missing modules or 404 responses)
 // to help users diagnose which resource failed and why.


### PR DESCRIPTION
## Summary
- derive the occt-import-js worker path from `import.meta.url` so the worker loads via an absolute URL

## Testing
- `ls vendor/occt-import-js/dist`
- `python3 -m http.server 8000` (in a separate session)
- `curl -I http://localhost:8000/vendor/occt-import-js/dist/occt-import-js-worker.js`


------
https://chatgpt.com/codex/tasks/task_e_68c6f17c0af08325a1ed9816a7ff811d