### PR TITLE
feat: add Flask server for static files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+__pycache__/

--- a/server.py
+++ b/server.py
@@ -1,0 +1,22 @@
+from flask import Flask, send_from_directory
+
+app = Flask(__name__, static_folder='.', static_url_path='')
+
+@app.route('/')
+def index():
+    return send_from_directory('.', 'index.html')
+
+@app.route('/vendor/<path:filename>')
+def vendor(filename):
+    return send_from_directory('vendor', filename)
+
+@app.route('/main.js')
+def main_js():
+    return send_from_directory('.', 'main.js')
+
+@app.route('/style.css')
+def style_css():
+    return send_from_directory('.', 'style.css')
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8080)


### PR DESCRIPTION
## Summary
- serve project files with a minimal Flask app rooted at the repository
- ignore node_modules and Python cache directories

## Testing
- `pip install flask` *(fails: Could not find a version that satisfies the requirement flask)*
- `python server.py` *(fails: ModuleNotFoundError: No module named 'flask')*
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7286dbfd08325b6f5b699d00a6b8b