### PR TITLE
Add 50MB file size limit and validation for uploads

### DIFF
--- a/main.js
+++ b/main.js
@@ -102,6 +102,15 @@ function handleFileSelect(event) {
     if (!file) return;
 
     resetUI();
+
+    const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
+    if (file.size > MAX_FILE_SIZE) {
+        alert('File is too large. Maximum allowed size is 50 MB.');
+        loaderElement.classList.add('hidden');
+        conversionLoaderElement.classList.add('hidden');
+        return;
+    }
+
     loaderElement.classList.remove('hidden');
 
     currentFileName = file.name;


### PR DESCRIPTION
## Summary
- prevent oversize uploads by checking file size in `handleFileSelect`
- keep loaders hidden and alert user when file exceeds 50MB

## Testing
- `node --check main.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68c72b20b47883258fa27f6733fd0794