### PR TITLE
Log unhandled promise rejections

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,6 +31,11 @@ window.addEventListener('error', (event) => {
     }
 }, true);
 
+window.addEventListener('unhandledrejection', (event) => {
+    console.error('Unhandled promise rejection:', event.reason);
+    alert('An unexpected error occurred. Check the console for details.');
+});
+
 function init() {
     // Scene
     scene = new THREE.Scene();


### PR DESCRIPTION
## Summary
- Log unhandled promise rejections with a dedicated event listener
- Alert users about unexpected unhandled rejections

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_e_68c72b252bac8325acf8427777d0c902