### PR TITLE
Ensure current model reset on STEP import errors

### DIFF
--- a/main.js
+++ b/main.js
@@ -168,6 +168,7 @@ async function loadStepModel(fileName, fileContent) {
                 child.material.dispose();
             }
         });
+        currentModel = null;
     }
 
     const importManager = new ImportManager();
@@ -180,10 +181,12 @@ async function loadStepModel(fileName, fileContent) {
         } else {
             console.error('Failed to load model:', result.message);
             alert('Error: Could not load the model. Check the console for details.');
+            currentModel = null;
         }
     } catch (error) {
         console.error(`An error occurred during STEP model import for "${fileName}":`, error);
         alert('An unexpected error occurred. Check the console for details.');
+        currentModel = null;
     } finally {
         loaderElement.classList.add('hidden');
         fileInput.value = ''; // Reset file input


### PR DESCRIPTION
## Summary
- Clear `currentModel` before importing a new STEP model
- Guarantee `currentModel` remains null on import failure or exceptions

## Testing
- `node --check main.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68c72b2a40ec832594e5172d6c3ea0b4