### PR TITLE
Handle file load errors and reset input on early exits

### DIFF
--- a/main.js
+++ b/main.js
@@ -99,7 +99,12 @@ function resetUI() {
 
 function handleFileSelect(event) {
     const file = event.target.files[0];
-    if (!file) return;
+    if (!file) {
+        loaderElement.classList.add('hidden');
+        conversionLoaderElement.classList.add('hidden');
+        fileInput.value = '';
+        return;
+    }
 
     resetUI();
     loaderElement.classList.remove('hidden');
@@ -110,6 +115,11 @@ function handleFileSelect(event) {
     if (extension === 'stp' || extension === 'step') {
         showThreeJsViewer();
         const reader = new FileReader();
+        reader.onerror = () => {
+            loaderElement.classList.add('hidden');
+            alert('Failed to read file.');
+            fileInput.value = '';
+        };
         reader.onload = (e) => {
             const fileContent = e.target.result;
             loadStepModel(file.name, fileContent);
@@ -122,6 +132,8 @@ function handleFileSelect(event) {
     } else {
         alert('Unsupported file format.');
         loaderElement.classList.add('hidden');
+        conversionLoaderElement.classList.add('hidden');
+        fileInput.value = '';
     }
 }
 


### PR DESCRIPTION
## Summary
- Reset file input and hide loaders when no file is selected or an unsupported format is chosen
- Add FileReader error handler to alert users and reset file input if reading fails

## Testing
- `node --check main.js && echo 'Syntax OK'`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c72b2df4e08325823f9cbdb105ce48