### PR TITLE
Enable CORS support for vendor resources

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,6 +1,8 @@
 from flask import Flask, send_from_directory
+from flask_cors import CORS
 
 app = Flask(__name__, static_folder='.', static_url_path='')
+CORS(app)
 
 @app.route('/')
 def index():


### PR DESCRIPTION
## Summary
- import and initialize CORS in server to allow cross-origin vendor resource access

## Testing
- `python -m py_compile server.py`
- `pip install flask-cors` *(failed: Could not connect to proxy)*
- `python -c "import flask_cors"` *(failed: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68c730c6ef88832587a75bfda54c5fda