### PR TITLE
Use Flask static handler for frontend assets

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,22 +1,12 @@
-from flask import Flask, send_from_directory
+from flask import Flask
 
 app = Flask(__name__, static_folder='.', static_url_path='')
 
+
 @app.route('/')
 def index():
-    return send_from_directory('.', 'index.html')
-
-@app.route('/vendor/<path:filename>')
-def vendor(filename):
-    return send_from_directory('vendor', filename)
-
-@app.route('/main.js')
-def main_js():
-    return send_from_directory('.', 'main.js')
-
-@app.route('/style.css')
-def style_css():
-    return send_from_directory('.', 'style.css')
+    """Serve the main application page."""
+    return app.send_static_file('index.html')
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8080)


### PR DESCRIPTION
## Summary
- Serve `index.html` via Flask's `send_static_file`
- Drop explicit routes for `main.js`, `style.css`, and `vendor` assets and rely on Flask's built-in static handling

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68c730c961f483259cc67be467e038f5