### PR TITLE
Dispose textures when unloading models

### DIFF
--- a/main.js
+++ b/main.js
@@ -191,7 +191,35 @@ async function loadStepModel(fileName, fileContent) {
         currentModel.traverse(child => {
             if (child.isMesh) {
                 child.geometry.dispose();
-                child.material.dispose();
+                child.geometry = null;
+
+                const materials = Array.isArray(child.material) ? child.material : [child.material];
+                materials.forEach(material => {
+                    if (!material) return;
+                    const textureProps = [
+                        'map',
+                        'normalMap',
+                        'roughnessMap',
+                        'metalnessMap',
+                        'bumpMap',
+                        'alphaMap',
+                        'aoMap',
+                        'displacementMap',
+                        'emissiveMap',
+                        'lightMap',
+                        'envMap',
+                        'specularMap',
+                        'gradientMap'
+                    ];
+                    textureProps.forEach(prop => {
+                        if (material[prop]) {
+                            material[prop].dispose();
+                            material[prop] = null;
+                        }
+                    });
+                    material.dispose();
+                });
+                child.material = null;
             }
         });
         currentModel = null;


### PR DESCRIPTION
## Summary
- Ensure STEP model cleanup disposes textures and materials
- Null references to textures and materials for garbage collection

## Testing
- `node --check main.js`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c730cb9af08325bd9eeef9f4cc2169