### PR TITLE
Revoke object URL after download link use

### DIFF
--- a/main.js
+++ b/main.js
@@ -177,8 +177,12 @@ async function handleConversion() {
         downloadLink.textContent = `Download ${stpFileName}`;
         downloadLink.classList.remove('hidden');
 
+        downloadLink.addEventListener('click', () => {
+            setTimeout(() => URL.revokeObjectURL(downloadLink.href), 0);
+        }, { once: true });
+
         conversionLoaderElement.classList.add('hidden');
-        
+
         alert("SLDPRT to STP conversion is a complex process requiring a server-side converter.\n\nThis is a demonstration of the UI flow. A placeholder model is shown, and you can download a dummy STP file.");
 
     }, 1500);


### PR DESCRIPTION
## Summary
- add one-time click handler to remove dummy STP object URL after user clicks download link

## Testing
- `node --check main.js && echo "Syntax OK"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c730cd96d08325b267cbb942714dae