### PR TITLE
Check file extension before splitting and notify if absent

### DIFF
--- a/main.js
+++ b/main.js
@@ -17,6 +17,21 @@ const conversionLoaderElement = document.getElementById('conversion-loader');
 const convertBtn = document.getElementById('convert-btn');
 const downloadLink = document.getElementById('download-link');
 
+// Error notification system
+const errorNotification = document.createElement('div');
+errorNotification.id = 'error-notification';
+errorNotification.classList.add('hidden');
+document.body.appendChild(errorNotification);
+
+function showErrorNotification(message) {
+    errorNotification.textContent = message;
+    errorNotification.classList.remove('hidden');
+    setTimeout(() => {
+        errorNotification.classList.add('hidden');
+        errorNotification.textContent = '';
+    }, 5000);
+}
+
 // Set occt-import-js worker path for local vendor copy
 SetOCCTWorkerUrl(
     new URL('./vendor/occt-import-js/dist/occt-import-js-worker.js', import.meta.url).href
@@ -124,6 +139,13 @@ function handleFileSelect(event) {
     loaderElement.classList.remove('hidden');
 
     currentFileName = file.name;
+    if (!file.name.includes('.')) {
+        showErrorNotification('Filename lacks extension');
+        loaderElement.classList.add('hidden');
+        conversionLoaderElement.classList.add('hidden');
+        fileInput.value = '';
+        return;
+    }
     const extension = file.name.split('.').pop().toLowerCase();
 
     if (extension === 'stp' || extension === 'step') {

--- a/style.css
+++ b/style.css
@@ -84,3 +84,16 @@ input[type="file"] {
 .hidden {
     display: none;
 }
+
+#error-notification {
+    position: fixed;
+    top: 10px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(198, 40, 40, 0.9);
+    color: white;
+    padding: 10px 20px;
+    border-radius: 4px;
+    z-index: 3;
+    box-shadow: 0 4px 15px rgba(0,0,0,0.4);
+}


### PR DESCRIPTION
## Summary
- Add lightweight error notification system to display user-friendly messages
- Guard against filenames without extensions before determining file type
- Style error notification banner for visibility

## Testing
- `npm test` (fails: enoent, package.json not found)
- `node --check main.js`
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7385ec27c8325adfc26a5d8e55e65