### PR TITLE
Add server test and document running pytest

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@
 3. Open your browser and navigate to [http://localhost:8080](http://localhost:8080).
 4. Upload a `.stp`, `.step`, or `.sldprt` file and inspect the model.
 
+## Running Tests
+Execute the test suite with:
+```bash
+pytest
+```
+
 ## Troubleshooting
 - **Missing dependencies**: If `Flask` is not installed, run `pip install Flask`.
 - **Asset loading errors**: Ensure the `vendor` directory and static assets are present and paths are correct.

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,12 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from server import app
+
+
+def test_index_route():
+    client = app.test_client()
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b"<title>STP/STEP File Viewer</title>" in response.data


### PR DESCRIPTION
## Summary
- add pytest to verify home page returns 200 and includes the expected title
- mention running `pytest` in the README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68c738640e308325843976d541d1f1f0