### PR TITLE
Add tests for static assets and missing routes

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,3 +10,15 @@ def test_index_route():
     response = client.get('/')
     assert response.status_code == 200
     assert b"<title>STP/STEP File Viewer</title>" in response.data
+
+
+def test_static_asset_served():
+    client = app.test_client()
+    response = client.get('/style.css')
+    assert response.status_code == 200
+
+
+def test_nonexistent_route_returns_404():
+    client = app.test_client()
+    response = client.get('/does-not-exist')
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- add test for serving `/style.css`
- add test to ensure nonexistent routes return 404

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68c73c787b8c832586ad24ebec60e77a