### PR TITLE
Add JS unit tests for file selection and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: python -m pip install --upgrade pip
+      - run: pip install flask pytest
+      - run: pytest
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm test
+        working-directory: tests/js

--- a/static/handleFileSelect.js
+++ b/static/handleFileSelect.js
@@ -1,0 +1,63 @@
+export function createHandleFileSelect({
+    resetUI,
+    showThreeJsViewer,
+    showRevViewer,
+    loadStepModel,
+    loadSldprtModel,
+    loaderElement,
+    conversionLoaderElement,
+    fileInput,
+    convertBtn,
+    alertFn = alert,
+    setCurrentFileName,
+}) {
+    const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
+
+    return function handleFileSelect(event) {
+        const file = event.target.files[0];
+        if (!file) {
+            loaderElement.classList.add('hidden');
+            conversionLoaderElement.classList.add('hidden');
+            fileInput.value = '';
+            return;
+        }
+
+        resetUI();
+
+        if (file.size > MAX_FILE_SIZE) {
+            alertFn('File is too large. Maximum allowed size is 50 MB.');
+            loaderElement.classList.add('hidden');
+            conversionLoaderElement.classList.add('hidden');
+            return;
+        }
+
+        loaderElement.classList.remove('hidden');
+
+        setCurrentFileName(file.name);
+        const extension = file.name.split('.').pop().toLowerCase();
+
+        if (extension === 'stp' || extension === 'step') {
+            showThreeJsViewer();
+            const reader = new FileReader();
+            reader.onerror = () => {
+                loaderElement.classList.add('hidden');
+                alertFn('Failed to read file.');
+                fileInput.value = '';
+            };
+            reader.onload = (e) => {
+                const fileContent = e.target.result;
+                loadStepModel(file.name, fileContent);
+            };
+            reader.readAsArrayBuffer(file);
+        } else if (extension === 'sldprt') {
+            showRevViewer();
+            convertBtn.classList.remove('hidden');
+            loadSldprtModel(file);
+        } else {
+            alertFn('Unsupported file format.');
+            loaderElement.classList.add('hidden');
+            conversionLoaderElement.classList.add('hidden');
+            fileInput.value = '';
+        }
+    };
+}

--- a/static/main.js
+++ b/static/main.js
@@ -5,6 +5,7 @@ import { ImportManager, SetOCCTWorkerUrl } from 'occt-import-js';
 // The real library exposes `CADMode` which we map through the import
 // map to our local vendor copy.
 import { CADMode } from 'rev-viewer';
+import { createHandleFileSelect } from './handleFileSelect.js';
 
 let scene, camera, renderer, controls, currentModel, revViewer;
 let currentFileName = '';
@@ -100,55 +101,6 @@ function resetUI() {
     downloadLink.download = '';
     downloadLink.textContent = '';
     currentFileName = '';
-}
-
-function handleFileSelect(event) {
-    const file = event.target.files[0];
-    if (!file) {
-        loaderElement.classList.add('hidden');
-        conversionLoaderElement.classList.add('hidden');
-        fileInput.value = '';
-        return;
-    }
-
-    resetUI();
-
-    const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
-    if (file.size > MAX_FILE_SIZE) {
-        alert('File is too large. Maximum allowed size is 50 MB.');
-        loaderElement.classList.add('hidden');
-        conversionLoaderElement.classList.add('hidden');
-        return;
-    }
-
-    loaderElement.classList.remove('hidden');
-
-    currentFileName = file.name;
-    const extension = file.name.split('.').pop().toLowerCase();
-
-    if (extension === 'stp' || extension === 'step') {
-        showThreeJsViewer();
-        const reader = new FileReader();
-        reader.onerror = () => {
-            loaderElement.classList.add('hidden');
-            alert('Failed to read file.');
-            fileInput.value = '';
-        };
-        reader.onload = (e) => {
-            const fileContent = e.target.result;
-            loadStepModel(file.name, fileContent);
-        };
-        reader.readAsArrayBuffer(file);
-    } else if (extension === 'sldprt') {
-        showRevViewer();
-        convertBtn.classList.remove('hidden');
-        loadSldprtModel(file);
-    } else {
-        alert('Unsupported file format.');
-        loaderElement.classList.add('hidden');
-        conversionLoaderElement.classList.add('hidden');
-        fileInput.value = '';
-    }
 }
 
 async function handleConversion() {
@@ -285,6 +237,20 @@ function showRevViewer() {
     viewerContainer.classList.add('hidden');
     revViewerContainer.classList.remove('hidden');
 }
+
+const handleFileSelect = createHandleFileSelect({
+    resetUI,
+    showThreeJsViewer,
+    showRevViewer,
+    loadStepModel,
+    loadSldprtModel,
+    loaderElement,
+    conversionLoaderElement,
+    fileInput,
+    convertBtn,
+    alertFn: alert,
+    setCurrentFileName: (name) => { currentFileName = name; },
+});
 
 function centerCamera(object) {
     const box = new THREE.Box3().setFromObject(object);

--- a/tests/js/handleFileSelect.test.js
+++ b/tests/js/handleFileSelect.test.js
@@ -1,0 +1,114 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHandleFileSelect } from '../../static/handleFileSelect.js';
+
+class MockFileReader {
+  constructor() {
+    this.onload = null;
+    this.onerror = null;
+  }
+  readAsArrayBuffer() {
+    if (this.onload) {
+      const buffer = new ArrayBuffer(8);
+      this.onload({ target: { result: buffer } });
+    }
+  }
+}
+
+global.FileReader = MockFileReader;
+
+function createMockElement() {
+  const classes = new Set();
+  return {
+    classList: {
+      add: (...cls) => cls.forEach(c => classes.add(c)),
+      remove: (...cls) => cls.forEach(c => classes.delete(c)),
+      contains: c => classes.has(c),
+    },
+    value: '',
+    innerHTML: '',
+  };
+}
+
+function createDeps() {
+  const loaderElement = createMockElement();
+  loaderElement.classList.add('hidden');
+  const conversionLoaderElement = createMockElement();
+  conversionLoaderElement.classList.add('hidden');
+  const fileInput = createMockElement();
+  const convertBtn = createMockElement();
+  convertBtn.classList.add('hidden');
+
+  return {
+    resetUI: () => {},
+    showThreeJsViewer: () => {},
+    showRevViewer: () => {},
+    loadStepModel: () => {},
+    loadSldprtModel: () => {},
+    loaderElement,
+    conversionLoaderElement,
+    fileInput,
+    convertBtn,
+    alertFn: () => {},
+    setCurrentFileName: () => {},
+  };
+}
+
+test('accepts .stp and .step files', () => {
+  for (const ext of ['stp', 'step']) {
+    const deps = createDeps();
+    let showCalled = false;
+    let loadArgs;
+    deps.showThreeJsViewer = () => { showCalled = true; };
+    deps.loadStepModel = (name, content) => { loadArgs = [name, content]; };
+    const handler = createHandleFileSelect(deps);
+    const file = { name: `model.${ext}`, size: 1 };
+    handler({ target: { files: [file] } });
+    assert.equal(showCalled, true);
+    assert.equal(loadArgs[0], `model.${ext}`);
+    assert.ok(loadArgs[1] instanceof ArrayBuffer);
+  }
+});
+
+test('accepts .sldprt files', () => {
+  const deps = createDeps();
+  let revCalled = false;
+  let loadArg;
+  deps.showRevViewer = () => { revCalled = true; };
+  deps.loadSldprtModel = (file) => { loadArg = file; };
+  const handler = createHandleFileSelect(deps);
+  const file = { name: 'part.sldprt', size: 1 };
+  handler({ target: { files: [file] } });
+  assert.equal(revCalled, true);
+  assert.equal(loadArg, file);
+  assert.equal(deps.convertBtn.classList.contains('hidden'), false);
+});
+
+test('handles files without extension', () => {
+  const deps = createDeps();
+  let alertMsg;
+  deps.alertFn = (msg) => { alertMsg = msg; };
+  const handler = createHandleFileSelect(deps);
+  const file = { name: 'file', size: 1 };
+  handler({ target: { files: [file] } });
+  assert.equal(alertMsg, 'Unsupported file format.');
+  assert.ok(deps.loaderElement.classList.contains('hidden'));
+  assert.ok(deps.conversionLoaderElement.classList.contains('hidden'));
+  assert.equal(deps.fileInput.value, '');
+});
+
+test('handles oversized files', () => {
+  const deps = createDeps();
+  let alertMsg;
+  let showCalled = false;
+  let revCalled = false;
+  deps.alertFn = (msg) => { alertMsg = msg; };
+  deps.showThreeJsViewer = () => { showCalled = true; };
+  deps.showRevViewer = () => { revCalled = true; };
+  const handler = createHandleFileSelect(deps);
+  const bigFile = { name: 'big.stp', size: 50 * 1024 * 1024 + 1 };
+  handler({ target: { files: [bigFile] } });
+  assert.equal(alertMsg, 'File is too large. Maximum allowed size is 50 MB.');
+  assert.equal(showCalled, false);
+  assert.equal(revCalled, false);
+});

--- a/tests/js/package.json
+++ b/tests/js/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "cad-inspection-js-tests",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}


### PR DESCRIPTION
## Summary
- Refactor file selection logic into a reusable module
- Add JavaScript unit tests covering file extension and size handling
- Configure GitHub Actions to run Python and JS tests

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68c73c7b5530832591c7dc1c7643330a