### PR TITLE
Fix occt-import-js worker path

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -22,7 +22,7 @@ const downloadLink = document.getElementById('download-link');
 
 // Set occt-import-js worker path for local vendor copy
 SetOCCTWorkerUrl(
-    new URL('./vendor/occt-import-js/dist/occt-import-js-worker.js', import.meta.url).href
+    new URL('./vendor/occt-import-js/occt-import-js-worker.js', import.meta.url).href
 );
 
 // Log asset loading failures (e.g., missing modules or 404 responses)

--- a/static/vendor/occt-import-js/occt-import-js-worker.js
+++ b/static/vendor/occt-import-js/occt-import-js-worker.js
@@ -1,1 +1,8 @@
-// Placeholder for occt-import-js-worker.js
+// Load the compiled OCCT importer inside a web worker.
+// The main thread will communicate with the library through this worker.
+// The actual library logic lives in the bundled `occt-import-js.js` script,
+// which in turn loads the accompanying WebAssembly module.
+
+importScripts('./dist/occt-import-js.js');
+
+// Further message handling is managed by the library once it initializes.


### PR DESCRIPTION
## Summary
- add minimal occt-import-js worker wrapper
- point application to the correct worker location

## Testing
- `curl -I http://localhost:8080/vendor/occt-import-js/occt-import-js-worker.js`
- `curl -I http://localhost:8080/vendor/occt-import-js/dist/occt-import-js.wasm`
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68c7403949c88325b3d297f3292220aa