### PR TITLE
test: verify three.js module served

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -18,6 +18,13 @@ def test_static_asset_served():
     assert response.status_code == 200
 
 
+def test_three_js_module_served():
+    """Ensure a representative Three.js module is accessible."""
+    client = app.test_client()
+    response = client.get('/vendor/three/build/math/Line3.js')
+    assert response.status_code == 200
+
+
 def test_nonexistent_route_returns_404():
     client = app.test_client()
     response = client.get('/does-not-exist')


### PR DESCRIPTION
## Summary
- Add test ensuring a representative Three.js module is served with a 200 status

## Testing
- `pytest` *(fails: No module named 'flask')*
- `pip install Flask` *(fails: Could not find a version that satisfies the requirement Flask)*

------
https://chatgpt.com/codex/tasks/task_e_68c74f4c307c83258ec7fff726f64dbd