### PR TITLE
Show banner for asset load failures

### DIFF
--- a/static/main.js
+++ b/static/main.js
@@ -11,6 +11,7 @@ let scene, camera, renderer, controls, currentModel, revViewer;
 let currentFileName = '';
 let currentObjectUrl = null;
 let objectUrlRevokeTimeout = null;
+let errorBanner = null;
 
 const viewerContainer = document.getElementById('viewer-container');
 const revViewerContainer = document.getElementById('rev-viewer-container');
@@ -31,6 +32,22 @@ window.addEventListener('error', (event) => {
     const asset = event.target?.src || event.filename;
     if (asset) {
         console.error(`Failed to load asset "${asset}":`, event.message || event.error);
+
+        if (!errorBanner) {
+            errorBanner = document.createElement('div');
+            errorBanner.style.position = 'fixed';
+            errorBanner.style.top = '0';
+            errorBanner.style.left = '0';
+            errorBanner.style.width = '100%';
+            errorBanner.style.backgroundColor = '#c0392b';
+            errorBanner.style.color = '#fff';
+            errorBanner.style.padding = '8px';
+            errorBanner.style.textAlign = 'center';
+            errorBanner.style.zIndex = '1000';
+            document.body.appendChild(errorBanner);
+        }
+
+        errorBanner.textContent = `Failed to load asset "${asset}". See console for details.`;
     }
 }, true);
 


### PR DESCRIPTION
## Summary
- show prominent on-screen banner when a static asset fails to load

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `mv static/vendor/three/build/three.module.js static/vendor/three/build/three.module.js.bak && cd static && python -m http.server 8000 & curl -I http://localhost:8000/vendor/three/build/three.module.js` *(returns HTTP/1.0 404 File not found)*
- `node <<'NODE' ... NODE` *(simulated error event adds banner with expected text)*

------
https://chatgpt.com/codex/tasks/task_e_68c784b8d2b8832592f58b34e38a4d3e