### PR TITLE
Use relative vendor import paths

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>STP/STEP File Viewer</title>
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="./style.css">
 </head>
 <body>
     <div id="viewer-container"></div>
@@ -23,13 +23,13 @@
     <script type="importmap">
     {
         "imports": {
-            "three": "/vendor/three/build/three.module.js",
-            "three/addons/": "/vendor/three/addons/",
-            "occt-import-js": "/vendor/occt-import-js/occt-import-js.module.js",
-            "rev-viewer": "/vendor/rev-viewer/rev-viewer.js"
+            "three": "./vendor/three/build/three.module.js",
+            "three/addons/": "./vendor/three/addons/",
+            "occt-import-js": "./vendor/occt-import-js/occt-import-js.module.js",
+            "rev-viewer": "./vendor/rev-viewer/rev-viewer.js"
         }
     }
     </script>
-    <script type="module" src="/main.js"></script>
+    <script type="module" src="./main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make index.html load vendor dependencies via relative paths
- reference local CSS and modules with relative paths to support subdirectory hosting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `curl -I http://localhost:8000/index.html`
- `curl -I http://localhost:8000/vendor/three/build/three.module.js`
- `curl -I http://localhost:8001/static/index.html`
- `curl -I http://localhost:8001/static/vendor/three/build/three.module.js`


------
https://chatgpt.com/codex/tasks/task_e_68c784bac5a883259db61f5e1494b8ac